### PR TITLE
Removed net461 to be able to compile tests

### DIFF
--- a/src/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/src/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
I'm not really thinking that you'll merge this, but I wanted to show you the changes that I made to build on MacOS.

In attempting to run the tests on MacOS I had to remove the reference to the .NET Framework 4.6.1. 
Is there a way to handle this scenario? I'm thinking it's easy enough to have multiple *.csprog files and a build for dotnetcore separate from 4.6.1